### PR TITLE
Improve code for better minification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Allows you to get the device pixel ratio using JavaScript.
 
 ## Size and delivery
 
-Currently, `getDevicePixelRatio.js` compresses to around 318 bytes (~0.3 KB), after minify and gzip. To minify, you might try these online tools: [Microsoft Ajax Minifier]:(http://ajaxmin.codeplex.com/), [Uglify]:(http://marijnhaverbeke.nl/uglifyjs), [Yahoo Compressor]:(http://refresh-sf.com/yui/), or [Closure Compiler](http://closure-compiler.appspot.com/home). Serve with gzip compression.
+Currently, `getDevicePixelRatio.js` compresses to around 221 bytes (~0.2 KB), after minify and gzip. To minify, you might try these online tools: [Microsoft Ajax Minifier](http://ajaxmin.codeplex.com/), [Uglify](http://marijnhaverbeke.nl/uglifyjs), [Yahoo Compressor](http://refresh-sf.com/yui/), or [Closure Compiler](http://closure-compiler.appspot.com/home). Serve with gzip compression.
 
 ## Sample
 

--- a/getDevicePixelRatio-min.js
+++ b/getDevicePixelRatio-min.js
@@ -1,2 +1,2 @@
 ﻿/*! GetDevicePixelRatio | Author: Tyson Matanich, 2012 | License: MIT */
-(function(n){n.getDevicePixelRatio=function(){var t=1;return n.screen.systemXDPI!==undefined&&n.screen.logicalXDPI!==undefined&&n.screen.systemXDPI>n.screen.logicalXDPI?t=n.screen.systemXDPI/n.screen.logicalXDPI:n.devicePixelRatio!==undefined&&(t=n.devicePixelRatio),t}})(this);
+(function(b){b.getDevicePixelRatio=function(){var a=b.screen||{},c=a.systemXDPI||1,a=a.logicalXDPI||1;return c>a?c/a:b.devicePixelRatio||1}})(this);

--- a/getDevicePixelRatio.js
+++ b/getDevicePixelRatio.js
@@ -1,15 +1,14 @@
 ﻿/*! GetDevicePixelRatio | Author: Tyson Matanich, 2012 | License: MIT */
 (function (window) {
+	// device pixel ratio even before dom ready
+	// http://stackoverflow.com/a/29913175
 	window.getDevicePixelRatio = function () {
-		var ratio = 1;
-		// To account for zoom, change to use deviceXDPI instead of systemXDPI
-		if (window.screen.systemXDPI !== undefined && window.screen.logicalXDPI !== undefined && window.screen.systemXDPI > window.screen.logicalXDPI) {
-			// Only allow for values > 1
-			ratio = window.screen.systemXDPI / window.screen.logicalXDPI;
-		}
-		else if (window.devicePixelRatio !== undefined) {
-			ratio = window.devicePixelRatio;
-		}
-		return ratio;
+		var screen = window.screen || {};
+		var systemXDPI = screen.systemXDPI || 1;
+		var logicalXDPI = screen.logicalXDPI || 1;
+		// To account for zoom, change to deviceXDPI instead of systemXDPI
+		if (systemXDPI > logicalXDPI) return systemXDPI / logicalXDPI;
+		// Fall back to legacy devicePixelRatio or return 1
+		else return window.devicePixelRatio || 1;
 	};
 })(this);


### PR DESCRIPTION
Thanks for the function, going to need it for responsive images.
Since I need to include this in the html head, I thought after
reviewing it, that it could be easily compressed even more.

I slighly adjusted and simplified the implementation a bit
to improve minification. Mainly by getting some base objects
like `screen` into variables, so the minfier only sees them once.

I also changed the checks a little, which should IMO be safe. You
explicitly check for `!== undefiend`, but I guess only positive numbers
really make sense in the later calculation. Therefore a simple `|| 1` seems
even a bit safer, as it protects from a possible division by zero.

Google closure compiler minfies the new code to 151 bytes, while
the current implementation is at 281 bytes 😃 I double checked that
I did not include any errors and tried to make sure the logic is sane.
Ie. it is now guaranteed to never return zero, which seems desirable!

Thanks and kind regards!